### PR TITLE
fix-start-branch-conflict

### DIFF
--- a/lib/thegarage/gitx/cli/start_command.rb
+++ b/lib/thegarage/gitx/cli/start_command.rb
@@ -24,12 +24,14 @@ module Thegarage
         private
 
         def valid_new_branch_name?(branch)
-          return false if remote_branches.include?(branch)
+          return false if repo_branches.include?(branch)
           branch =~ VALID_BRANCH_NAME_REGEX
         end
 
-        def remote_branches
-          @remote_branches ||= repo.branches.each_name(:remote).to_a.map { |branch| branch.split('/').last }
+        def repo_branches
+          @branch_names ||= repo.branches.each_name.map do |branch|
+            branch.split('/').last
+          end
         end
       end
     end

--- a/lib/thegarage/gitx/version.rb
+++ b/lib/thegarage/gitx/version.rb
@@ -1,5 +1,5 @@
 module Thegarage
   module Gitx
-    VERSION = '2.4.0'
+    VERSION = '2.4.1'
   end
 end

--- a/spec/thegarage/gitx/cli/start_command_spec.rb
+++ b/spec/thegarage/gitx/cli/start_command_spec.rb
@@ -56,8 +56,11 @@ describe Thegarage::Gitx::Cli::StartCommand do
         should meet_expectations
       end
     end
-    context 'when branch already exists in remote repo' do
+    context 'when branch already exists in local repo' do
+      let(:branches) { double(each_name: ['bar']) }
       before do
+        expect(repo).to receive(:branches).and_return(branches)
+
         expect(cli).to receive(:ask).and_return('new-branch')
 
         expect(cli).to receive(:checkout_branch).with('master').ordered
@@ -65,7 +68,25 @@ describe Thegarage::Gitx::Cli::StartCommand do
         expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
         expect(cli).to receive(:checkout_branch).with('new-branch').ordered
 
-        cli.start 'master'
+        cli.start 'bar'
+      end
+      it 'prompts user to enter a new branch name' do
+        should meet_expectations
+      end
+    end
+    context 'when branch already exists in remote repo' do
+      let(:branches) { double(each_name: ['origin/bar']) }
+      before do
+        expect(repo).to receive(:branches).and_return(branches)
+
+        expect(cli).to receive(:ask).and_return('new-branch')
+
+        expect(cli).to receive(:checkout_branch).with('master').ordered
+        expect(cli).to receive(:run_cmd).with('git pull').ordered
+        expect(repo).to receive(:create_branch).with('new-branch', 'master').ordered
+        expect(cli).to receive(:checkout_branch).with('new-branch').ordered
+
+        cli.start 'bar'
       end
       it 'prompts user to enter a new branch name' do
         should meet_expectations


### PR DESCRIPTION
### Changelog
- Fix git start command to detect when branch already exists locally.
