### PR TITLE
oauth-client

### DIFF
--- a/lib/thegarage/gitx/github.rb
+++ b/lib/thegarage/gitx/github.rb
@@ -5,7 +5,6 @@ module Thegarage
   module Gitx
     module Github
       REVIEW_CONTEXT = 'peer_review'
-      CLIENT_URL = 'https://github.com/thegarage/thegarage-gitx'
       CLIENT_ID = '3212b0bfb60acaf792fc'
       CLIENT_SECRET = '264e30f443a6762b6be365ea00bdeaaa9427523e'
       PULL_REQUEST_FOOTER = <<-EOS.dedent
@@ -99,19 +98,20 @@ module Thegarage
         password = ask("Github password for #{username}: ", :echo => false)
         say ''
         client = Octokit::Client.new(login: username, password: password)
-        response = client.create_authorization(authorization_request_options)
+        options = authorization_request_options
+        url = "/authorizations/#{CLIENT_ID}/#{options[:fingerprint]}"
+        response = client.put(url, options)
         response.token
       end
 
       def authorization_request_options
         timestamp = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%S%z')
-        note = "The Garage Git eXtensions - #{github_slug} #{timestamp}"
+        note = "#{github_slug} #{timestamp}"
         fingerprint = Digest::SHA2.hexdigest(note)
         options = {
           :scopes => ['repo'],
           :note => note,
-          :note_url => CLIENT_URL,
-          :client_id => CLIENT_ID,
+          :note_url => "https://github.com/#{github_slug}",
           :client_secret => CLIENT_SECRET,
           :fingerprint => fingerprint,
           :accept => 'application/vnd.github.mirage-preview+json'

--- a/spec/thegarage/gitx/cli/review_command_spec.rb
+++ b/spec/thegarage/gitx/cli/review_command_spec.rb
@@ -219,7 +219,7 @@ describe Thegarage::Gitx::Cli::ReviewCommand do
       let(:github_password) { 'secretz' }
       let(:authorization_token) { '123981239123' }
       before do
-        stub_request(:post, "https://ryan@codecrate.com:secretz@api.github.com/authorizations").
+        stub_request(:put, %r{https://ryan@codecrate.com:secretz@api.github.com/authorizations/#{Thegarage::Gitx::Github::CLIENT_ID}/}).
           to_return(:status => 200, :body => JSON.dump(token: authorization_token), :headers => {'Content-Type' => 'application/json'})
 
         expect(cli).to receive(:ask).with('Github password for ryan@codecrate.com: ', {:echo => false}).and_return(github_password)
@@ -257,7 +257,7 @@ describe Thegarage::Gitx::Cli::ReviewCommand do
       let(:authorization_token) { '123981239123' }
       let(:two_factor_auth_token) { '456456' }
       before do
-        stub_request(:post, "https://ryan@codecrate.com:secretz@api.github.com/authorizations").
+        stub_request(:put, %r{https://ryan@codecrate.com:secretz@api.github.com/authorizations/#{Thegarage::Gitx::Github::CLIENT_ID}/}).
           with(headers: {'X-GitHub-OTP' => two_factor_auth_token}).
           to_return(:status => 200, :body => JSON.dump(token: authorization_token), :headers => {'Content-Type' => 'application/json'})
 


### PR DESCRIPTION
Use official oauth client for authorizations

Use new `fingerprint` attribute to uniquely identify project
authorization and prevent creation of duplicate tokens for each project.

Fixes #33
