### PR TITLE
review-release-from-any-branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ update the local feature branch with latest remote changes plus upstream release
 
 integrate the current feature branch into an aggregate branch (ex: prototype, staging)
 
-## git review
+## git review <feature_branch_name (optional, default: current_branch)>
 
 create a pull request on github for peer review of the current branch.  This command is re-runnable
 in order to re-assign pull requests.

--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ options:
 NOTE: the `--bump` option will also update the pull request commit status to mark the branch as 'pending peer review'.
 This setting is cleared when a reviewer approves or rejects the pull request.
 
-## git release
+## git release <feature_branch_name (optional, default: current_branch)
 
-release the current feature branch to master.  This operation will perform the following:
+release the feature branch to master.  This operation will perform the following:
 
-* pull in latest code from remote branch
-* merge in latest code from master branch
+* pull latest code from remote feature branch
+* pull latest code from master branch
 * prompt user to confirm they actually want to perform the release
+* check if pull request commit status is currently successful
 * merge current branch into master
 * (optional) cleanup merged branches from remote server
 

--- a/lib/thegarage/gitx/cli/release_command.rb
+++ b/lib/thegarage/gitx/cli/release_command.rb
@@ -14,11 +14,12 @@ module Thegarage
 
         desc 'release', 'release the current branch to production'
         method_option :cleanup, :type => :boolean, :desc => 'cleanup merged branches after release'
-        def release
+        def release(branch = nil)
           return unless yes?("Release #{current_branch.name} to production? (y/n)", :green)
 
-          branch = current_branch.name
+          branch ||= current_branch.name
           assert_not_protected_branch!(branch, 'release')
+          checkout_branch(branch)
           execute_command(UpdateCommand, :update)
 
           find_or_create_pull_request(branch)

--- a/lib/thegarage/gitx/cli/review_command.rb
+++ b/lib/thegarage/gitx/cli/review_command.rb
@@ -1,7 +1,6 @@
 require 'thor'
 require 'thegarage/gitx'
 require 'thegarage/gitx/cli/base_command'
-require 'thegarage/gitx/cli/update_command'
 require 'thegarage/gitx/github'
 
 module Thegarage
@@ -41,10 +40,10 @@ module Thegarage
         method_option :approve, :type => :boolean, :desc => 'approve the pull request an post comment on pull request'
         method_option :reject, :type => :boolean, :desc => 'reject the pull request an post comment on pull request'
         # @see http://developer.github.com/v3/pulls/
-        def review
+        def review(branch = nil)
           fail 'Github authorization token not found' unless authorization_token
 
-          branch = current_branch.name
+          branch ||= current_branch.name
           pull_request = find_or_create_pull_request(branch)
           bump_pull_request(pull_request) if options[:bump]
           approve_pull_request(pull_request) if options[:approve]

--- a/lib/thegarage/gitx/github.rb
+++ b/lib/thegarage/gitx/github.rb
@@ -1,6 +1,7 @@
 require 'octokit'
 require 'fileutils'
 require 'yaml'
+require 'thegarage/gitx/cli/update_command'
 
 module Thegarage
   module Gitx
@@ -20,6 +21,7 @@ module Thegarage
       def find_or_create_pull_request(branch)
         pull_request = find_pull_request(branch)
         pull_request ||= begin
+          checkout_branch(branch)
           execute_command(Thegarage::Gitx::Cli::UpdateCommand, :update)
           pull_request = create_pull_request(branch)
           say 'Created pull request: '

--- a/lib/thegarage/gitx/version.rb
+++ b/lib/thegarage/gitx/version.rb
@@ -1,5 +1,5 @@
 module Thegarage
   module Gitx
-    VERSION = '2.12.0'
+    VERSION = '2.13.0'
   end
 end

--- a/spec/thegarage/gitx/cli/integrate_command_spec.rb
+++ b/spec/thegarage/gitx/cli/integrate_command_spec.rb
@@ -98,7 +98,7 @@ describe Thegarage::Gitx::Cli::IntegrateCommand do
         expect(cli).to receive(:run_cmd).with("git merge feature-branch").ordered
         expect(cli).to receive(:run_cmd).with("git push origin HEAD").ordered
         expect(cli).to receive(:run_cmd).with("git checkout feature-branch").ordered
-
+        expect(cli).to receive(:run_cmd).with('git checkout feature-branch').ordered
         expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %s%n%b'").and_return("2013-01-01 did some stuff").ordered
 
         stub_request(:post, 'https://api.github.com/repos/thegarage/thegarage-gitx/pulls').to_return(:status => 201, :body => new_pull_request.to_json, :headers => {'Content-Type' => 'application/json'})

--- a/spec/thegarage/gitx/cli/release_command_spec.rb
+++ b/spec/thegarage/gitx/cli/release_command_spec.rb
@@ -96,6 +96,7 @@ describe Thegarage::Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:yes?).with('Release feature-branch to production? (y/n)', :green).and_return(true)
         expect(cli).to receive(:yes?).with('Branch status is currently: pending.  Proceed with release? (y/n)', :red).and_return(true)
 
+        expect(cli).to receive(:run_cmd).with("git checkout feature-branch").ordered
         expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %s%n%b'").and_return("2013-01-01 did some stuff").ordered
         expect(cli).to receive(:run_cmd).with("git checkout master").ordered
         expect(cli).to receive(:run_cmd).with("git pull origin master").ordered
@@ -138,9 +139,6 @@ describe Thegarage::Gitx::Cli::ReleaseCommand do
         end
       end
       it 'runs expected commands' do
-        should meet_expectations
-      end
-      it 'prunes merged branches (git cleanup)' do
         should meet_expectations
       end
     end

--- a/spec/thegarage/gitx/cli/release_command_spec.rb
+++ b/spec/thegarage/gitx/cli/release_command_spec.rb
@@ -61,6 +61,7 @@ describe Thegarage::Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:yes?).and_return(true)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
+        expect(cli).to receive(:run_cmd).with("git checkout feature-branch").ordered
         expect(cli).to receive(:run_cmd).with("git checkout master").ordered
         expect(cli).to receive(:run_cmd).with("git pull origin master").ordered
         expect(cli).to receive(:run_cmd).with("git merge --no-ff feature-branch").ordered
@@ -68,6 +69,29 @@ describe Thegarage::Gitx::Cli::ReleaseCommand do
 
         VCR.use_cassette('pull_request_does_exist_with_success_status') do
           cli.release
+        end
+      end
+      it 'runs expected commands' do
+        should meet_expectations
+      end
+    end
+    context 'when target_branch is not nil and user confirms release and pull request exists with success status' do
+      before do
+        expect(cli).to receive(:execute_command).with(Thegarage::Gitx::Cli::UpdateCommand, :update)
+        expect(cli).to receive(:execute_command).with(Thegarage::Gitx::Cli::IntegrateCommand, :integrate, 'staging')
+        expect(cli).to_not receive(:execute_command).with(Thegarage::Gitx::Cli::CleanupCommand, :cleanup)
+
+        expect(cli).to receive(:yes?).and_return(true)
+        allow(cli).to receive(:authorization_token).and_return(authorization_token)
+
+        expect(cli).to receive(:run_cmd).with("git checkout feature-branch").ordered
+        expect(cli).to receive(:run_cmd).with("git checkout master").ordered
+        expect(cli).to receive(:run_cmd).with("git pull origin master").ordered
+        expect(cli).to receive(:run_cmd).with("git merge --no-ff feature-branch").ordered
+        expect(cli).to receive(:run_cmd).with("git push origin HEAD").ordered
+
+        VCR.use_cassette('pull_request_does_exist_with_success_status') do
+          cli.release 'feature-branch'
         end
       end
       it 'runs expected commands' do
@@ -96,6 +120,7 @@ describe Thegarage::Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:yes?).with('Release feature-branch to production? (y/n)', :green).and_return(true)
         expect(cli).to receive(:yes?).with('Branch status is currently: pending.  Proceed with release? (y/n)', :red).and_return(true)
 
+        expect(cli).to receive(:run_cmd).with("git checkout feature-branch").ordered
         expect(cli).to receive(:run_cmd).with("git checkout feature-branch").ordered
         expect(cli).to receive(:run_cmd).with("git log master...feature-branch --reverse --no-merges --pretty=format:'* %s%n%b'").and_return("2013-01-01 did some stuff").ordered
         expect(cli).to receive(:run_cmd).with("git checkout master").ordered
@@ -129,6 +154,7 @@ describe Thegarage::Gitx::Cli::ReleaseCommand do
         expect(cli).to receive(:yes?).and_return(true)
         allow(cli).to receive(:authorization_token).and_return(authorization_token)
 
+        expect(cli).to receive(:run_cmd).with("git checkout feature-branch").ordered
         expect(cli).to receive(:run_cmd).with("git checkout master").ordered
         expect(cli).to receive(:run_cmd).with("git pull origin master").ordered
         expect(cli).to receive(:run_cmd).with("git merge --no-ff feature-branch").ordered


### PR DESCRIPTION
### Changelog
* Support optional branch name for git review command
This allows for running git review from *any* branch and it will
"do the right thing".  For example, approving a review request
no longer needs to be done from the feature branch.
* Support releasing feature branch from any repo
Allow users to run the release command without requiring
that they first checkout the feature branch.  This allows for
developers to sign-off and release a feature branch much quicker.
* bump version
* update docs