### PR TITLE
fix-updating-commit-status

### DIFF
--- a/lib/thegarage/gitx/cli/review_command.rb
+++ b/lib/thegarage/gitx/cli/review_command.rb
@@ -70,17 +70,17 @@ module Thegarage
 
         def bump_pull_request(pull_request)
           comment = comment_from_template(pull_request, BUMP_COMMENT_PREFIX, BUMP_COMMENT_FOOTER)
-          set_review_status('pending', 'Peer review in progress')
+          update_review_status(pull_request, 'pending', 'Peer review in progress')
         end
 
         def reject_pull_request(pull_request)
           comment = comment_from_template(pull_request, REJECTION_COMMENT_PREFIX, REJECTION_COMMENT_FOOTER)
-          set_review_status('failure', 'Peer review rejected')
+          update_review_status(pull_request, 'failure', 'Peer review rejected')
         end
 
         def approve_pull_request(pull_request)
           comment = comment_from_template(pull_request, APPROVAL_COMMENT_PREFIX, APPROVAL_COMMENT_FOOTER)
-          set_review_status('success', 'Peer review approved')
+          update_review_status(pull_request, 'success', 'Peer review approved')
         end
 
         def comment_from_template(pull_request, prefix, footer)
@@ -88,11 +88,6 @@ module Thegarage
           comment = [prefix, text].join("\n\n")
           comment = comment.gsub(footer, '').chomp.strip
           github_client.add_comment(github_slug, pull_request.number, comment)
-        end
-
-        def set_review_status(state, description)
-          latest_commit = repo.head.target_id
-          update_review_status(latest_commit, state, description)
         end
       end
     end

--- a/lib/thegarage/gitx/github.rb
+++ b/lib/thegarage/gitx/github.rb
@@ -52,7 +52,8 @@ module Thegarage
       end
 
       # Update build status with peer review status
-      def update_review_status(commit_sha, state, description)
+      def update_review_status(pull_request, state, description)
+        commit_sha = pull_request.head.sha
         github_client.create_status(github_slug, commit_sha, state, context: REVIEW_CONTEXT, description: description)
       end
 

--- a/lib/thegarage/gitx/version.rb
+++ b/lib/thegarage/gitx/version.rb
@@ -1,5 +1,5 @@
 module Thegarage
   module Gitx
-    VERSION = '2.13.0'
+    VERSION = '2.13.1'
   end
 end

--- a/spec/fixtures/vcr_cassettes/pull_request_does_exist_with_success_status.yml
+++ b/spec/fixtures/vcr_cassettes/pull_request_does_exist_with_success_status.yml
@@ -75,7 +75,7 @@ http_interactions:
       - d818ddef80f4c7d10683dd483558952a
     body:
       encoding: UTF-8
-      string: '[{"html_url":"https://path/to/html/pull/request","issue_url":"https://api/path/to/issue/url","number":10,"head":{"ref":"branch_name"}}]'
+      string: '[{"html_url":"https://path/to/html/pull/request","issue_url":"https://api/path/to/issue/url","number":10,"head":{"ref":"branch_name", "sha": "e12da4"}}]'
     http_version:
   recorded_at: Tue, 05 Aug 2014 16:36:03 GMT
 - request:


### PR DESCRIPTION
### Changelog
Fix updating commit status when local repo is on another branch

Fix #44

Instead of relying on the local repo to lookup the commit SHA,
use the github API response.  This allows for updating the commit status
when the local repo is out of sync with the remote server.